### PR TITLE
Chore/release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,11 +13,11 @@ jobs:
         id: release
         with: 
           release-type: node
-          package-name: "@ioncakephper/cli-starter"
-          changelog-path: CHANGELOG.md
+          # package-name: "@ioncakephper/cli-starter"
+          # changelog-path: CHANGELOG.md
           # You can customize the commit message for the release PR
           # release-as: "major" # Uncomment to force a major release
-          # default-branch: main # Default is main, but good to be explicit
+          default-branch: main # Default is main, but good to be explicit
 
       - name: Publish to npm
         if: ${{ steps.release.outputs.releases_created }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,7 +17,7 @@ jobs:
           # changelog-path: CHANGELOG.md
           # You can customize the commit message for the release PR
           # release-as: "major" # Uncomment to force a major release
-          default-branch: main # Default is main, but good to be explicit
+          # default-branch: main # Default is main, but good to be explicit
 
       - name: Publish to npm
         if: ${{ steps.release.outputs.releases_created }}


### PR DESCRIPTION
The default-branch option was commented out in the release-please workflow file. This allows release-please to automatically detect the default branch.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Comment out the `package-name` and `changelog-path` lines in the `release-please.yml` GitHub workflow file.

### Why are these changes being made?

These changes adjust settings within the release workflow to potentially use default or inferred values by commenting specifics, possibly for simplification or troubleshooting. The NPM_TOKEN configuration remains unchanged to ensure the necessary environment variable for npm publication is retained.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->