### PR TITLE
feat: Add npm publish step to release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,16 +5,24 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
       - uses: google-github-actions/release-please-action@v4
+        id: release
         with:
-          token: ${{ secrets.CLI_STARTER_PAT }} # Use a PAT to allow triggering other workflows
           release-type: node
+          # package-name: @ioncakephper/cli-starter
+          # changelog-path: CHANGELOG.md
+          # You can customize the commit message for the release PR
+          # release-as: "major" # Uncomment to force a major release
+          # default-branch: main # Default is main, but good to be explicit
 
+      - name: Publish to npm
+        if: ${{ steps.release.outputs.releases_created }}
+        run: |
+          npm config set //registry.npmjs.org/:_authToken ${{ secrets.NPM_TOKEN }}
+          npm publish
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This commit adds a new step to the release-please workflow to automatically publish the package to npm when a new release is created.

The step is configured to use the NPM_TOKEN secret to authenticate with npm.

The step is conditional and only runs if the release-please action outputs that a release was created.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add an npm publish step to the release workflow in the GitHub Actions configuration.

### Why are these changes being made?

These changes automate the process of publishing packages to npm upon the creation of a release, reducing manual intervention and ensuring consistency in the deployment process. The addition manages authentication using a secure token and fits seamlessly into the existing workflow triggered on the main branch.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->